### PR TITLE
фикс Search

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
@@ -88,6 +88,9 @@ class SearchFragment : Fragment() {
             if (searchMask.isNotEmpty()) {
                 changeDrawableClearText(binding.editTextSearch)
                 viewModel.searchDebounce(searchMask, 0)
+            } else {
+                changeDrawableSearchIcon(binding.editTextSearch)
+                viewModel.stopSearch()
             }
         }
 
@@ -140,8 +143,11 @@ class SearchFragment : Fragment() {
             searchResultsRV.isVisible = false
             vacanciesCountText.isVisible = false
         }
-        vacancySearchAdapter.vacancies.clear()
-        vacancySearchAdapter.notifyDataSetChanged()
+        val adapterListSize = vacancySearchAdapter.vacancies.size
+        if (adapterListSize > 0) {
+            vacancySearchAdapter.vacancies.clear()
+            vacancySearchAdapter.notifyItemRangeRemoved(0, adapterListSize)
+        }
     }
 
     private fun showContent(state: SearchState.Content) {

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
@@ -26,13 +26,16 @@ class SearchViewModel(
 
     private var latestSearchText: String? = null
     private var searchJob: Job? = null
-    private var isNextPageLoading = false
 
     private val _toast = SingleLiveEvent<String>()
     fun observeToast(): LiveData<String> = _toast
 
     private val _state = MutableLiveData<SearchState>()
     fun observeState(): LiveData<SearchState> = _state
+
+    fun stopSearch() {
+        searchJob?.cancel()
+    }
 
     fun searchDebounce(changedText: String, page: Int) {
         if (changedText.isEmpty()/* || latestSearchText == changedText*/) {

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
@@ -20,8 +20,8 @@ class SearchViewModel(
     private val interactor: SearchInteractor,
 ) : ViewModel() {
     companion object {
-        const val SEARCH_DEBOUNCE_DELAY = 5000L
-        const val ITEMS_PER_PAGE = 10
+        const val SEARCH_DEBOUNCE_DELAY = 2000L
+        const val ITEMS_PER_PAGE = 20
     }
 
     private var latestSearchText: String? = null

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -102,6 +102,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/placeHolderImage"
                 android:gravity="center"
+                android:paddingHorizontal="@dimen/dp_36"
                 tools:text="@string/failed_to_get_vacancies" />
         </RelativeLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="vacancy">Вакансия</string>
     <string name="enter_your_request">Введите запрос</string>
     <string name="no_internet">Нет интернета</string>
-    <string name="failed_to_get_vacancies">Не удалось получить список вакансий</string>
+    <string name="failed_to_get_vacancies">Не удалось получить\nсписок вакансий</string>
     <string name="failed_to_get_list">Не удалось получить список</string>
     <string name="no_vacancies">Таких вакансий нет</string>
     <string name="no_region">Такого региона нет</string>


### PR DESCRIPTION
- добавил отключение джоба корутины поиска при пустом поисковом запросе
- горизонтальные отступы 36dp у сообщения об ошибке на fragment_search (по макету сложно судить, возможно 30px, визуально похоже)
- перенос в строке Не удалось получить\nсписок вакансий
- очистка RV не через NotifyDataSetChanged
- смена иконки при пустой строке поиска
- параметры вернул: 20 вакансий на страницу, задержка дебаунс поиска 2 сек.