### PR TITLE
Task 143

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/common/data/ErrorType.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/common/data/ErrorType.kt
@@ -1,11 +1,7 @@
 package ru.practicum.android.diploma.common.data
 
 abstract class ErrorType
-
 class Success : ErrorType()
-
 class ServerInternalError : ErrorType()
-
 class NoInternetError : ErrorType()
-
 class BadRequestError : ErrorType()

--- a/app/src/main/java/ru/practicum/android/diploma/common/presentation/EditTextSearchIcon.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/common/presentation/EditTextSearchIcon.kt
@@ -1,0 +1,8 @@
+package ru.practicum.android.diploma.common.presentation
+
+import ru.practicum.android.diploma.R
+
+enum class EditTextSearchIcon(val drawableId: Int) {
+    SEARCH_ICON(R.drawable.search_24px_input_edittext_icon),
+    CLEAR_ICON(R.drawable.clear_24px_input_edittext_button)
+}

--- a/app/src/main/java/ru/practicum/android/diploma/favorites/data/impl/FavouriteVacancyRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/favorites/data/impl/FavouriteVacancyRepositoryImpl.kt
@@ -33,7 +33,6 @@ class FavouriteVacancyRepositoryImpl(
         emit(vacancyId)
     }
 
-
     private fun convertToVacancyEntity(track: VacancyDetails): VacancyEntity {
         return vacancyDbConverter.map(track)
     }

--- a/app/src/main/java/ru/practicum/android/diploma/search/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/data/network/RetrofitNetworkClient.kt
@@ -15,12 +15,47 @@ import ru.practicum.android.diploma.search.data.dto.VacancySearchRequest
 import ru.practicum.android.diploma.search.data.dto.VacancySearchResponse
 import ru.practicum.android.diploma.search.domain.models.VacanciesNotFoundType
 import ru.practicum.android.diploma.util.isConnected
+import java.io.IOException
 import java.net.HttpURLConnection
 
 class RetrofitNetworkClient(
     private val apiService: HhApiService,
     private val context: Context,
 ) : NetworkClient {
+
+    override suspend fun doRequest(dto: Any): ResponseBase {
+        if (!isConnected(context)) {
+            return ResponseBase(NoInternetError())
+        }
+        return withContext(Dispatchers.IO) {
+            try {
+                when (dto) {
+                    is VacancySearchRequest -> {
+                        val options = searchOptions(dto)
+
+                        val response = apiService.findVacancies(options)
+                        when (response.code()) {
+                            HttpURLConnection.HTTP_OK -> convertVacancySearchResponse(response.body())
+                            HttpURLConnection.HTTP_NOT_FOUND -> ResponseBase(VacanciesNotFoundType())
+                            else -> ResponseBase(BadRequestError())
+                        }
+
+                    }
+
+                    else -> ResponseBase(BadRequestError())
+                }
+
+            } catch (e: HttpException) {
+                e.message?.let { Log.e("Http", it) }
+                ResponseBase(ServerInternalError())
+            }
+            // выполняется, если в эмуляторе интернет смартфона включен, а на компьютере интернет отпал
+            catch (e: IOException) {
+                e.message?.let { Log.e("IO", it) }
+                ResponseBase(ServerInternalError())
+            }
+        }
+    }
 
     private fun searchOptions(dto: VacancySearchRequest): HashMap<String, String> {
         val options: HashMap<String, String> = HashMap()
@@ -35,44 +70,17 @@ class RetrofitNetworkClient(
         return options
     }
 
-    override suspend fun doRequest(dto: Any): ResponseBase {
-        if (!isConnected(context)) {
-            return ResponseBase(NoInternetError())
+    private fun convertVacancySearchResponse(responseBody: VacancySearchResponse?): ResponseBase =
+        if (responseBody == null) {
+            ResponseBase(VacanciesNotFoundType())
+        } else {
+            VacancySearchResponse(
+                responseBody.found,
+                responseBody.page,
+                responseBody.pages,
+                responseBody.perPage,
+                responseBody.items,
+            )
         }
-        return withContext(Dispatchers.IO) {
-            try {
-                when (dto) {
-                    is VacancySearchRequest -> {
-                        val options = searchOptions(dto)
-                        val response = apiService.findVacancies(options)
-                        when (response.code()) {
-                            HttpURLConnection.HTTP_OK -> {
-                                val vacancySearchResponse = response.body()
-                                if (vacancySearchResponse == null || vacancySearchResponse.items.isEmpty()) {
-                                    ResponseBase(VacanciesNotFoundType())
-                                } else {
-                                    VacancySearchResponse(
-                                        vacancySearchResponse.found,
-                                        vacancySearchResponse.page,
-                                        vacancySearchResponse.pages,
-                                        vacancySearchResponse.perPage,
-                                        vacancySearchResponse.items,
-                                    )
-                                }
-                            }
 
-                            HttpURLConnection.HTTP_NOT_FOUND -> ResponseBase(VacanciesNotFoundType())
-                            else -> ResponseBase(BadRequestError())
-                        }
-                    }
-
-                    else -> ResponseBase(BadRequestError())
-                }
-
-            } catch (e: HttpException) {
-                e.message?.let { Log.e("Http", it) }
-                ResponseBase(ServerInternalError())
-            }
-        }
-    }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/search/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/data/network/RetrofitNetworkClient.kt
@@ -71,7 +71,7 @@ class RetrofitNetworkClient(
     }
 
     private fun convertVacancySearchResponse(responseBody: VacancySearchResponse?): ResponseBase =
-        if (responseBody == null) {
+        if (responseBody == null || responseBody.items.isEmpty()) {
             ResponseBase(VacanciesNotFoundType())
         } else {
             VacancySearchResponse(

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
@@ -108,8 +108,8 @@ class SearchFragment : Fragment() {
         with(binding.editTextSearch) {
             // изменение текста
             doOnTextChanged { text, start, before, count ->
-                // любое изменение прерывает текущий поиск
-                viewModel.stopSearch()
+                // любое изменение сбрасывает текущий поиск
+                resetSearchParams()
                 searchMask = text.toString().trim()
                 // иконка в поле поиска
                 setEditTextIconBySearchMask()
@@ -125,8 +125,8 @@ class SearchFragment : Fragment() {
                     && event.rawX >= binding.editTextSearch.right
                     - binding.editTextSearch.compoundDrawables[2].bounds.width()
                 ) {
-                    // остановим поиск при очистке поля
-                    viewModel.stopSearch()
+                    // сбросим параметры для нового поиска
+                    resetSearchParams()
                     searchMask = ""
                     setEditTextIconBySearchMask()
                     binding.editTextSearch.setText(searchMask)
@@ -237,6 +237,11 @@ class SearchFragment : Fragment() {
         }
 
         binding.vacanciesCountText.append(" (${vacancySearchAdapter.vacancies.size})")
+    }
+
+    private fun resetSearchParams() {
+        viewModel.stopSearch()
+        currentPage = 0
     }
 
     private fun loadNextPage() {

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
@@ -78,6 +78,9 @@ class SearchFragment : Fragment() {
 
         // подпишемся на результаты поиска
         viewModel.observeState().observe(viewLifecycleOwner) { state ->
+
+            Log.d("mine", "STATE=${state.javaClass}")
+
             when (state) {
                 is SearchState.Content -> {
                     isNextPageLoading = false
@@ -267,6 +270,9 @@ class SearchFragment : Fragment() {
     }
 
     private fun showErrorOrEmptySearch(type: ErrorType) {
+
+
+        Log.d("mine", "size=${vacancySearchAdapter.vacancies.size}")
         hideKeyboard()
         val errorMessage = getErrorMessage(type)
         if (vacancySearchAdapter.vacancies.size > 0) {

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/SearchFragment.kt
@@ -270,8 +270,6 @@ class SearchFragment : Fragment() {
     }
 
     private fun showErrorOrEmptySearch(type: ErrorType) {
-
-
         Log.d("mine", "size=${vacancySearchAdapter.vacancies.size}")
         hideKeyboard()
         val errorMessage = getErrorMessage(type)

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/VacancySearchViewHolder.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/VacancySearchViewHolder.kt
@@ -17,7 +17,8 @@ class VacancySearchViewHolder(
     private val trackCornerRadius: Int = itemView.context.resources.getDimensionPixelSize(R.dimen.logo_corner_radius)
 
     fun bind(item: VacancyBase) {
-        binding.vacancyNameAndCity.text = "${item.name}, ${item.employerInfo.areaName}"
+
+        binding.vacancyNameAndCity.text = "${this.bindingAdapterPosition+1}. ${item.name}, ${item.employerInfo.areaName}"
         binding.companyName.text = item.employerInfo.employerName
         binding.salaryText.text = Formatter.formatSalary(itemView.context, item.salaryInfo)
         Glide.with(itemView).load(item.employerInfo.employerLogoUrl).placeholder(R.drawable.logo_placeholder_image)

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/VacancySearchViewHolder.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/view/VacancySearchViewHolder.kt
@@ -17,8 +17,8 @@ class VacancySearchViewHolder(
     private val trackCornerRadius: Int = itemView.context.resources.getDimensionPixelSize(R.dimen.logo_corner_radius)
 
     fun bind(item: VacancyBase) {
-
-        binding.vacancyNameAndCity.text = "${this.bindingAdapterPosition+1}. ${item.name}, ${item.employerInfo.areaName}"
+        binding.vacancyNameAndCity.text =
+            "${this.bindingAdapterPosition + 1}. ${item.name}, ${item.employerInfo.areaName}"
         binding.companyName.text = item.employerInfo.employerName
         binding.salaryText.text = Formatter.formatSalary(itemView.context, item.salaryInfo)
         Glide.with(itemView).load(item.employerInfo.employerLogoUrl).placeholder(R.drawable.logo_placeholder_image)

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
@@ -75,6 +75,9 @@ class SearchViewModel(
 
     private fun processResult(searchResult: SearchResult?, errorType: ErrorType) {
         val vacancies = mutableListOf<VacancyBase>()
+
+        Log.d("mine", "errorType=${errorType.javaClass}")
+
         when (errorType) {
             is Success -> {
                 if (searchResult != null) {

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
@@ -36,13 +36,15 @@ class SearchViewModel(
     fun observeState(): LiveData<SearchState> = _state
 
     fun stopSearch() {
+        latestPage = null
         if (searchJob != null && searchJob!!.isActive) {
             searchJob?.cancel()
-            latestPage = null
         }
     }
 
     fun searchDebounce(changedText: String, page: Int) {
+        Log.d("mine", "page $page/$latestPage")
+
         if (changedText.trim().isEmpty() || page == latestPage) {
             return
         }

--- a/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/presentation/viewmodel/SearchViewModel.kt
@@ -1,5 +1,6 @@
 package ru.practicum.android.diploma.search.presentation.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -25,6 +26,7 @@ class SearchViewModel(
     }
 
     private var latestSearchText: String? = null
+    private var latestPage: Int? = null
     private var searchJob: Job? = null
 
     private val _toast = SingleLiveEvent<String>()
@@ -34,14 +36,19 @@ class SearchViewModel(
     fun observeState(): LiveData<SearchState> = _state
 
     fun stopSearch() {
-        searchJob?.cancel()
+        if (searchJob != null && searchJob!!.isActive) {
+            searchJob?.cancel()
+            latestPage = null
+        }
     }
 
     fun searchDebounce(changedText: String, page: Int) {
-        if (changedText.isEmpty()/* || latestSearchText == changedText*/) {
+        if (changedText.trim().isEmpty() || page == latestPage) {
             return
         }
+        Log.d("mine", "search($changedText, $page)")
 
+        latestPage = page
         latestSearchText = changedText
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
@@ -51,7 +58,7 @@ class SearchViewModel(
     }
 
     private fun searchRequest(newSearchText: String, page: Int) {
-        if (newSearchText.isNotEmpty()) {
+        if (newSearchText.trim().isNotEmpty()) {
             if (page == 0) {
                 renderState(SearchState.Loading)
             }

--- a/app/src/main/java/ru/practicum/android/diploma/vacancydetails/data/dto/VacancyDetailsResponse.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancydetails/data/dto/VacancyDetailsResponse.kt
@@ -74,4 +74,3 @@ data class NameInfoDto(
     val id: String?,
     val name: String
 )
-

--- a/app/src/main/java/ru/practicum/android/diploma/vacancydetails/presentation/view/VacancyDetailsFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancydetails/presentation/view/VacancyDetailsFragment.kt
@@ -45,7 +45,8 @@ class VacancyDetailsFragment : Fragment() {
                     val vacancyDetailsBinding = ItemVacancyDetailsViewBinding.bind(binding.root)
                     vacancyDetailsBinding.nameVacancyTv.text = Html.fromHtml(
                         "${state.vacancy.name}," +
-                            " ${state.vacancy.employerInfo.areaName}", Html.FROM_HTML_MODE_LEGACY
+                            " ${state.vacancy.employerInfo.areaName}",
+                        Html.FROM_HTML_MODE_LEGACY
                     )
                     vacancyDetailsBinding.nameCompanyTv.text = Html.fromHtml(
                         state.vacancy.employerInfo.employerName,
@@ -74,6 +75,7 @@ class VacancyDetailsFragment : Fragment() {
                         .transform(CenterCrop(), RoundedCorners(trackCornerRadius))
                         .into(vacancyDetailsBinding.logoCompanyIv)
                 }
+
                 else -> {}
             }
 


### PR DESCRIPTION
- иконки в поле поиска убрал в ENUM, функцию выбора иконки сделал одну (она мне в другом месте фрагмента тоже пригодилась)
- рефактор классов Retrofit: из сложного* метода DoRequest выделил конвертацию результата в отдельную функцию
- в классах Retrofit добавил отлов исключения IOException, т.к. у меня часто вылетало приложение, если отваливался интернет на компе (NoInternet не срабатывает в таком случае)

в Search Fragment:
- добавлено поле-флажок для ограничения подгрузки новой страницы (isNextPageLoading)
- сложные* методы разбиты на более мелкие
- дописана логика изменения поисковой строки
- появилась функция сброса текущего поискового запроса при изменении строки
- проверено поведение выборки и пагинации при переходе на другие фрагменты и обратно: исправлено и учтено поведение фрагмента на API 31 (TODO: проверить на других версиях API)
- например, кнопка очистить устанавливается сразу в onViewCreated, т.к. при навигации строка сохраняется в поле, а иконка нет
- доработан скроллинг списка вакансий - проверено что возврат с детальной его не меняет, попадает на то же место и не загружает новую страницу, если скролл стоял в конце (тут еще подумать)
- самое главное: ошибки догрузки новой страницы показываются в тосте, не меняя список
- проверена связка пагинации со стейтами при перезагрузке фрагмента (нужно больше тестов!)
- в SearchViewModel добавлена проверка на текущий номер страницы согласно заданию, работает. Еще проверять

Пока добавлена нумерация вакансий в списке и кол-во показанных в данный момент на плашке с кол-вом - пусть побудет для отладки.


* по мнению detekt 